### PR TITLE
README - add pointer to pytest-dev/unittest2pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # unittest2pytest [![Build Status](https://travis-ci.org/dropbox/unittest2pytest.svg?branch=master)](https://travis-ci.org/dropbox/unittest2pytest)
 
+## Warning: this is not the official unittest2pytest!
+
+Dropbox developed this package in parallel with (what became) the official `pytest-dev` package `unittest2pytest`, that
+has the same name and does the same thing. It's the one that has the name `unittest2pytest` on PyPI, and it can convert
+a few more assertions. Check it out [on Github](https://github.com/pytest-dev/unittest2pytest) or
+[on PyPI](https://pypi.python.org/pypi/unittest2pytest).
+
+# Description
+
 Convert unittest asserts to pytest rewritten asserts.
 
 py.test supports advanced assertion introspection, allowing it to provide more detailed error messages.


### PR DESCRIPTION
We were using `unittest2pytest` but due to googling and confusion didn't realize we were using the pytest-dev package from PyPI whilst looking at the source of this project. Adding a header to point to `unittest2pytest` will help future travellers.

Relates to #3.